### PR TITLE
Added [var] to prevent global "i" variable

### DIFF
--- a/library/p5.clickable.js
+++ b/library/p5.clickable.js
@@ -10,7 +10,7 @@ var cl_clickables = [];
 //This function is what makes the magic happen and should be ran after
 //each draw cycle.
 p5.prototype.runGUI = function () {
-	for (i = 0; i < cl_clickables.length; ++i) {
+	for (var i = 0; i < cl_clickables.length; ++i) {
 		if (cl_lastHovered != cl_clickables[i])
 			cl_clickables[i].onOutside();
 	}


### PR DESCRIPTION
Not having a [var] or a [let] in the for loop on line 13 caused a global variable "i", so I prevented that by putting [var]. I put [var] instead of [let] because every other variable declaration used [var]