### PR TITLE
Better Images (+ some minor tweaks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ The starting position of a Clickable defaults to (0, 0) and its size to (100, 50
 myButton = new Clickable(200,300);
 ```
 
+### Displaying a Clickable
+
+To **display** a Clickable, you have to call its `draw` method inside the `draw` function of your p5.js script.
+
+```javascript
+function draw(){ // This is the p5.js draw function.
+  //...
+  myButton.draw(); // <- Draw the 'myButton' Clickable
+  //...
+}
+```
+
+This is very important! If you don't call this method your button will not be shown and it also **won't respond
+to any events**!
+
 ### Moving a Clickable
 
 To move a Clickable you can change its `x` and `y` properties. You can also use this properties to read the current
@@ -102,21 +117,6 @@ myButton.textFont = "sans-serif"; //Font of the text (string)
 myButton.textScaled = false;       //Whether to scale the text with the clickable (boolean)
 ```
 
-### Displaying a Clickable
-
-To **display** a Clickable, you have to call its `draw` method inside the `draw` function of your p5.js script.
-
-```javascript
-function draw(){ // This is the p5.js draw function.
-  //...
-  myButton.draw(); // <- Draw the 'myButton' Clickable
-  //...
-}
-```
-
-This is very important! If you don't call this method your button will not be shown and it also **won't respond
-to any events**!
-
 ### Clickable Events
 
 The Clickable class provide four methods that are called when the user interacts with a Clickable: `onOutside`, `onHover`, `onPress` and `onRelease`.
@@ -152,6 +152,22 @@ myButton.onRelease = function(){
   console.log("I have been released!");
 }
 ```
+
+### Images in a Clickable
+
+You can add an image to a clickable like this:
+
+```javascript
+myButton.image = myImage; // myImage is an image loaded from p5's loadImage()
+```
+
+By default the image will stretch to fill the button, but you can disable the stretching with the `stretchImage` property.
+
+```javascript
+myButton.stretchImage = false;
+```
+
+Now, the image will be centered and bounded inside the button, but will retain its original aspect ratio.
 
 ## :beers: Contributing
 If there's a missing feature you'd like to see on p5.clickable, feel free to write it and submit a pull request. Something broke? Please try to fix it! Also feel free to submit issues, bug reports and requests for future features.

--- a/README.md
+++ b/README.md
@@ -161,13 +161,17 @@ You can add an image to a clickable like this:
 myButton.image = myImage; // myImage is an image loaded from p5's loadImage()
 ```
 
-By default the image will stretch to fill the button, but you can disable the stretching with the `stretchImage` property.
+By default the image will stretch to fill the button, but you can disable the stretching with the `fitImage` property.
 
 ```javascript
-myButton.stretchImage = false;
+myButton.fitImage = true; // fits the image inside the button with the image's original aspect ratio
 ```
 
-Now, the image will be centered and bounded inside the button, but will retain its original aspect ratio.
+You can also scale the image with the `imageScale` property.
+
+```javascript
+myButton.imageScale = 1.2; // useful if your image has some extra transparent padding
+```
 
 ## :beers: Contributing
 If there's a missing feature you'd like to see on p5.clickable, feel free to write it and submit a pull request. Something broke? Please try to fix it! Also feel free to submit issues, bug reports and requests for future features.

--- a/example/lib/p5.clickable.js
+++ b/example/lib/p5.clickable.js
@@ -72,7 +72,8 @@ function Clickable() {
 	
 	// image options
 	this.image = null; // image object from p5loadimage()
-	this.stretchImage = true; // when true, image will stretch to fill button
+	this.fitImage = false; // when true, image will stretch to fill button
+	this.imageScale = 1;
 	this.tint = null; // tint image using color
 	this.noTint = true; // default to disable tinting
 	this.filter = null; // filter effect
@@ -123,33 +124,27 @@ function Clickable() {
 	}
 
 	this.drawImage = function(){
-		if(this.stretchImage){
-			image(this.image, this.x, this.y, this.width, this.height);
-		}
-		else{
-			push();
-			let fitWidth;
-			let fitHeight;
+		push();
+		imageMode(CENTER);
+		let centerX = this.x + this.width / 2;
+		let centerY = this.y + this.height / 2;
+		let imgWidth = this.width;
+		let imgHeight = this.height;
+		if(this.fitImage){
 			let imageAspect = this.image.width / this.image.height;
 			let buttonAspect = this.width / this.height;
-			if(buttonAspect > imageAspect){ // button is wider than image
-				fitHeight = this.height;
-				fitWidth = this.width * (imageAspect / buttonAspect);
+			if(imageAspect > buttonAspect){ // image is wider than button
+				imgWidth = this.width;
+				imgHeight = this.height * (buttonAspect / imageAspect);
 			}
 			else{
-				fitWidth = this.width;
-				fitHeight = this.height * (buttonAspect / imageAspect);
+				imgWidth = this.width * (imageAspect / buttonAspect);
+				imgHeight = this.height;
 			}
-			imageMode(CENTER);
-			image(
-				this.image,
-				this.x + this.width / 2,
-				this.y + this.height / 2,
-				fitWidth,
-				fitHeight
-			);
-			pop();
 		}
+		
+		image(this.image, centerX, centerY, imgWidth * this.imageScale, imgHeight * this.imageScale);
+
 		if(this.tint && !this.noTint){
 			tint(this.tint)
 		} else {
@@ -158,6 +153,7 @@ function Clickable() {
 		if(this.filter){
 			filter(this.filter);
 		}
+		pop();
 	}
 
 	this.draw = function () {

--- a/example/lib/p5.clickable.js
+++ b/example/lib/p5.clickable.js
@@ -72,6 +72,7 @@ function Clickable() {
 	
 	// image options
 	this.image = null; // image object from p5loadimage()
+	this.imageMode = null; // image mode passed into p5's imageMode() function
 	this.tint = null; // tint image using color
 	this.noTint = true; // default to disable tinting
 	this.filter = null; // filter effect
@@ -79,7 +80,8 @@ function Clickable() {
 	this.updateTextSize = function () {
 		if (this.textScaled) {
 			for (let i = this.height; i > 0; i--) {
-				if (getTextBounds(this.text, this.textFont, i)[0] <= this.width && getTextBounds(this.text, this.textFont, i)[1] <= this.height) {
+				if (getTextBounds(this.text, this.textFont, i)[0] <= this.width
+					&& getTextBounds(this.text, this.textFont, i)[1] <= this.height) {
 					console.log("textbounds: " + getTextBounds(this.text, this.font, i));
 					console.log("boxsize: " + this.width + ", " + this.height);
 					this.textSize = i / 2;
@@ -100,13 +102,13 @@ function Clickable() {
 	}
 
 	this.onPress = function () {
-		//This fucking is ran when the clickable is pressed.
+		//This function is ran when the clickable is pressed.
 	}
 
 	this.onRelease = function () {
-		//This funcion is ran when the cursor was pressed and then
+		//This function is ran when the cursor was pressed and then
 		//released inside the clickable. If it was pressed inside and
-		//then released outside this won't work.
+		//then released outside this won't run.
 	}
 
 	this.locate = function (x, y) {
@@ -121,6 +123,7 @@ function Clickable() {
 	}
 
 	this.drawImage = function(){
+		imageMode(this.imageMode);
 		image(this.image, this.x, this.y, this.width, this.height);
 		if(this.tint && !this.noTint){
 			tint(this.tint)
@@ -133,6 +136,7 @@ function Clickable() {
 	}
 
 	this.draw = function () {
+		push();
 		fill(this.color);
 		stroke(this.stroke);
 		strokeWeight(this.strokeWeight);
@@ -152,6 +156,7 @@ function Clickable() {
 			if (mouseIsPressed && !cl_mouseWasPressed)
 				cl_lastClicked = this;
 		}
+		pop();
 	}
 
 	cl_clickables.push(this);

--- a/example/lib/p5.clickable.js
+++ b/example/lib/p5.clickable.js
@@ -73,7 +73,7 @@ function Clickable() {
 	// image options
 	this.image = null; // image object from p5loadimage()
 	this.fitImage = false; // when true, image will stretch to fill button
-	this.imageScale = 1;
+	this.imageScale = 1.0;
 	this.tint = null; // tint image using color
 	this.noTint = true; // default to disable tinting
 	this.filter = null; // filter effect

--- a/example/lib/p5.clickable.js
+++ b/example/lib/p5.clickable.js
@@ -72,7 +72,7 @@ function Clickable() {
 	
 	// image options
 	this.image = null; // image object from p5loadimage()
-	this.imageMode = null; // image mode passed into p5's imageMode() function
+	this.stretchImage = true; // when true, image will stretch to fill button
 	this.tint = null; // tint image using color
 	this.noTint = true; // default to disable tinting
 	this.filter = null; // filter effect
@@ -123,8 +123,33 @@ function Clickable() {
 	}
 
 	this.drawImage = function(){
-		imageMode(this.imageMode);
-		image(this.image, this.x, this.y, this.width, this.height);
+		if(this.stretchImage){
+			image(this.image, this.x, this.y, this.width, this.height);
+		}
+		else{
+			push();
+			let fitWidth;
+			let fitHeight;
+			let imageAspect = this.image.width / this.image.height;
+			let buttonAspect = this.width / this.height;
+			if(buttonAspect > imageAspect){ // button is wider than image
+				fitHeight = this.height;
+				fitWidth = this.width * (imageAspect / buttonAspect);
+			}
+			else{
+				fitWidth = this.width;
+				fitHeight = this.height * (buttonAspect / imageAspect);
+			}
+			imageMode(CENTER);
+			image(
+				this.image,
+				this.x + this.width / 2,
+				this.y + this.height / 2,
+				fitWidth,
+				fitHeight
+			);
+			pop();
+		}
 		if(this.tint && !this.noTint){
 			tint(this.tint)
 		} else {

--- a/example/sketch.js
+++ b/example/sketch.js
@@ -70,17 +70,31 @@ function setup() {
   // image will stretch to fill button by default
   click4 = new Clickable();
   click4.image = clickImg;
+  click4.imageScale = 1;
   click4.text = "";
   click4.locate(10, 200);
-  click4.resize(120, 100);
+  click4.resize(120, 90);
+  click4.onHover = function () {
+    click4.imageScale = 1.1;
+  }
+  click4.onOutside = function () {
+    click4.imageScale = 1;
+  }
 
-  // centering an image without stretching it
+  // centered and fitted
   click5 = new Clickable();
   click5.image = clickImg;
-  click5.stretchImage = false; // no stretching!
+  click5.fitImage = true; // no stretching!
+  click5.imageScale = 1;
   click5.text = "";
   click5.locate(140, 200);
-  click5.resize(120, 100);
+  click5.resize(120, 90);
+  click5.onHover = function () {
+    click5.imageScale = 1.1;
+  }
+  click5.onOutside = function () {
+    click5.imageScale = 1;
+  }
 }
 
 function draw() {

--- a/example/sketch.js
+++ b/example/sketch.js
@@ -38,9 +38,9 @@ function setup() {
 
   click2 = new Clickable();
   click2.cornerRadius = 0;
-  click2.locate(60, 60);
   click2.textScaled = true;
   click2.text = "hello";
+  click2.locate(60, 60);
   click2.resize(250, 100);
   click2.onOutside = function () {
     this.color = "#FFFFFF";
@@ -54,7 +54,7 @@ function setup() {
 
   click3 = new Clickable();
   click3.image = clickImg;
-  click3.locate(250,250);
+  click3.locate(280,250);
   click3.resize(100,100);
   click3.text = "";
   click3.onHover = function () {
@@ -66,6 +66,21 @@ function setup() {
     this.color = "#FFFFFF";
     this.noTint = true;
   }
+
+  // image will stretch to fill button by default
+  click4 = new Clickable();
+  click4.image = clickImg;
+  click4.text = "";
+  click4.locate(10, 200);
+  click4.resize(120, 100);
+
+  // centering an image without stretching it
+  click5 = new Clickable();
+  click5.image = clickImg;
+  click5.stretchImage = false; // no stretching!
+  click5.text = "";
+  click5.locate(140, 200);
+  click5.resize(120, 100);
 }
 
 function draw() {
@@ -73,4 +88,6 @@ function draw() {
   click1.draw();
   click2.draw();
   click3.draw();
+  click4.draw();
+  click5.draw();
 }

--- a/library/p5.clickable.js
+++ b/library/p5.clickable.js
@@ -72,6 +72,7 @@ function Clickable() {
 	
 	// image options
 	this.image = null; // image object from p5loadimage()
+	this.stretchImage = true; // when true, image will stretch to fill button
 	this.tint = null; // tint image using color
 	this.noTint = true; // default to disable tinting
 	this.filter = null; // filter effect
@@ -79,7 +80,8 @@ function Clickable() {
 	this.updateTextSize = function () {
 		if (this.textScaled) {
 			for (let i = this.height; i > 0; i--) {
-				if (getTextBounds(this.text, this.textFont, i)[0] <= this.width && getTextBounds(this.text, this.textFont, i)[1] <= this.height) {
+				if (getTextBounds(this.text, this.textFont, i)[0] <= this.width
+					&& getTextBounds(this.text, this.textFont, i)[1] <= this.height) {
 					console.log("textbounds: " + getTextBounds(this.text, this.font, i));
 					console.log("boxsize: " + this.width + ", " + this.height);
 					this.textSize = i / 2;
@@ -100,13 +102,13 @@ function Clickable() {
 	}
 
 	this.onPress = function () {
-		//This fucking is ran when the clickable is pressed.
+		//This function is ran when the clickable is pressed.
 	}
 
 	this.onRelease = function () {
-		//This funcion is ran when the cursor was pressed and then
+		//This function is ran when the cursor was pressed and then
 		//released inside the clickable. If it was pressed inside and
-		//then released outside this won't work.
+		//then released outside this won't run.
 	}
 
 	this.locate = function (x, y) {
@@ -121,7 +123,33 @@ function Clickable() {
 	}
 
 	this.drawImage = function(){
-		image(this.image, this.x, this.y, this.width, this.height);
+		if(this.stretchImage){
+			image(this.image, this.x, this.y, this.width, this.height);
+		}
+		else{
+			push();
+			let fitWidth;
+			let fitHeight;
+			let imageAspect = this.image.width / this.image.height;
+			let buttonAspect = this.width / this.height;
+			if(buttonAspect > imageAspect){ // button is wider than image
+				fitHeight = this.height;
+				fitWidth = this.width * (imageAspect / buttonAspect);
+			}
+			else{
+				fitWidth = this.width;
+				fitHeight = this.height * (buttonAspect / imageAspect);
+			}
+			imageMode(CENTER);
+			image(
+				this.image,
+				this.x + this.width / 2,
+				this.y + this.height / 2,
+				fitWidth,
+				fitHeight
+			);
+			pop();
+		}
 		if(this.tint && !this.noTint){
 			tint(this.tint)
 		} else {

--- a/library/p5.clickable.js
+++ b/library/p5.clickable.js
@@ -72,7 +72,8 @@ function Clickable() {
 	
 	// image options
 	this.image = null; // image object from p5loadimage()
-	this.stretchImage = true; // when true, image will stretch to fill button
+	this.fitImage = false; // when true, image will stretch to fill button
+	this.imageScale = 1;
 	this.tint = null; // tint image using color
 	this.noTint = true; // default to disable tinting
 	this.filter = null; // filter effect
@@ -123,33 +124,27 @@ function Clickable() {
 	}
 
 	this.drawImage = function(){
-		if(this.stretchImage){
-			image(this.image, this.x, this.y, this.width, this.height);
-		}
-		else{
-			push();
-			let fitWidth;
-			let fitHeight;
+		push();
+		imageMode(CENTER);
+		let centerX = this.x + this.width / 2;
+		let centerY = this.y + this.height / 2;
+		let imgWidth = this.width;
+		let imgHeight = this.height;
+		if(this.fitImage){
 			let imageAspect = this.image.width / this.image.height;
 			let buttonAspect = this.width / this.height;
-			if(buttonAspect > imageAspect){ // button is wider than image
-				fitHeight = this.height;
-				fitWidth = this.width * (imageAspect / buttonAspect);
+			if(imageAspect > buttonAspect){ // image is wider than button
+				imgWidth = this.width;
+				imgHeight = this.height * (buttonAspect / imageAspect);
 			}
 			else{
-				fitWidth = this.width;
-				fitHeight = this.height * (buttonAspect / imageAspect);
+				imgWidth = this.width * (imageAspect / buttonAspect);
+				imgHeight = this.height;
 			}
-			imageMode(CENTER);
-			image(
-				this.image,
-				this.x + this.width / 2,
-				this.y + this.height / 2,
-				fitWidth,
-				fitHeight
-			);
-			pop();
 		}
+		
+		image(this.image, centerX, centerY, imgWidth * this.imageScale, imgHeight * this.imageScale);
+
 		if(this.tint && !this.noTint){
 			tint(this.tint)
 		} else {
@@ -158,6 +153,7 @@ function Clickable() {
 		if(this.filter){
 			filter(this.filter);
 		}
+		pop();
 	}
 
 	this.draw = function () {

--- a/library/p5.clickable.js
+++ b/library/p5.clickable.js
@@ -79,8 +79,7 @@ function Clickable() {
 	this.updateTextSize = function () {
 		if (this.textScaled) {
 			for (let i = this.height; i > 0; i--) {
-				if (getTextBounds(this.text, this.textFont, i)[0] <= this.width
-					&& getTextBounds(this.text, this.textFont, i)[1] <= this.height) {
+				if (getTextBounds(this.text, this.textFont, i)[0] <= this.width && getTextBounds(this.text, this.textFont, i)[1] <= this.height) {
 					console.log("textbounds: " + getTextBounds(this.text, this.font, i));
 					console.log("boxsize: " + this.width + ", " + this.height);
 					this.textSize = i / 2;
@@ -101,13 +100,13 @@ function Clickable() {
 	}
 
 	this.onPress = function () {
-		//This function is ran when the clickable is pressed.
+		//This fucking is ran when the clickable is pressed.
 	}
 
 	this.onRelease = function () {
-		//This function is ran when the cursor was pressed and then
+		//This funcion is ran when the cursor was pressed and then
 		//released inside the clickable. If it was pressed inside and
-		//then released outside this won't run.
+		//then released outside this won't work.
 	}
 
 	this.locate = function (x, y) {

--- a/library/p5.clickable.js
+++ b/library/p5.clickable.js
@@ -79,7 +79,8 @@ function Clickable() {
 	this.updateTextSize = function () {
 		if (this.textScaled) {
 			for (let i = this.height; i > 0; i--) {
-				if (getTextBounds(this.text, this.textFont, i)[0] <= this.width && getTextBounds(this.text, this.textFont, i)[1] <= this.height) {
+				if (getTextBounds(this.text, this.textFont, i)[0] <= this.width
+					&& getTextBounds(this.text, this.textFont, i)[1] <= this.height) {
 					console.log("textbounds: " + getTextBounds(this.text, this.font, i));
 					console.log("boxsize: " + this.width + ", " + this.height);
 					this.textSize = i / 2;
@@ -100,13 +101,13 @@ function Clickable() {
 	}
 
 	this.onPress = function () {
-		//This fucking is ran when the clickable is pressed.
+		//This function is ran when the clickable is pressed.
 	}
 
 	this.onRelease = function () {
-		//This funcion is ran when the cursor was pressed and then
+		//This function is ran when the cursor was pressed and then
 		//released inside the clickable. If it was pressed inside and
-		//then released outside this won't work.
+		//then released outside this won't run.
 	}
 
 	this.locate = function (x, y) {

--- a/library/p5.clickable.js
+++ b/library/p5.clickable.js
@@ -73,7 +73,7 @@ function Clickable() {
 	// image options
 	this.image = null; // image object from p5loadimage()
 	this.fitImage = false; // when true, image will stretch to fill button
-	this.imageScale = 1;
+	this.imageScale = 1.0;
 	this.tint = null; // tint image using color
 	this.noTint = true; // default to disable tinting
 	this.filter = null; // filter effect


### PR DESCRIPTION
## Summary

1. Fitting and scaling for images
2. Documentation re-ordering and addition
3. Minor comment touch-ups

## Details

### Better Images

_I have not changed the default behavior and this PR is 100% backward compatible_

My main contribution is enhancements to _images_ in Clickables.

I added two properties, `fitImage` (boolean) and `imageScale` (float), and their associated functionality.

`fitImage` is false by default.

When `fitImage` is true, the image will retain its original aspect ratio but will be bounded inside of the button. The image's largest dimension will be equal to the buttons smallest dimension.

`imageScale` is `1.0` by default.

`imageScale` simply scales up and down the image, regardless of the bounds of the button.

I also added two examples to ./examples/sketch.js to showcase these new properties.

### Documentation change

I reordered the readme documentation so that the Displaying a Clickable section comes earlier, right after Creating a Clickable.

I remember learning matplotlib and being super frustrated when it took them 4 pages worth of tutorial before they mentioned that you need to call `plt.show()` to actually display the plot when using a terminal.

I figure that most people will want to know how to display the button before they change its appearance and functionality.

I also added a documentation section on images.

### Other minor improvements

- Some spelling corrections in comments
- Changed "work" to "run" to be more accurate in the comments of `Clickable.onRelease()`
