### PR TITLE
fix live example path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Welcome! This is **p5.clickable**, a [p5.js](http://p5js.org) library that lets you create and customize **buttons** and assign event-based behaviours to them. With **p5.clickable** you can create buttons and define what happens when the user *hovers over*, *clicks*, *releases* or *moves* the cursor *outside* of them.
 
-Can't wait? Check [this **live example**](https://lartu.github.io/projects/p5.clickable/example.html) to see some of the things this library can do. Its source code is available in the [example](example) folder of this repository.
+Can't wait? Check [this **live example**](https://lartu.github.io/p5.clickable/example/example.html) to see some of the things this library can do. Its source code is available in the [example](example) folder of this repository.
 
 >:warning: **Attention Contributors!** It seems that in one poorly checked pull request some of the newly contributes features were deleted. Sorry! I will add them again in the next release alongside all new features.
 


### PR DESCRIPTION
Hey :),
In this pull request, I am correcting the path to the [live example](https://github.com/Lartu/p5.clickable/blob/master/example/example.html).
But besides that, you also have to enable [GitHub pages](https://pages.github.com/) for this repository.
This already has been reported here: https://github.com/Lartu/p5.clickable/issues/25